### PR TITLE
Client side js reload

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -3,5 +3,8 @@
         ".git",
         "node_modules",
         "public"
-    ]
+    ],
+    "env": {
+        "NODE_ENV": "development"
+    }
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,7 @@
+{
+    "ignore": [
+        ".git",
+        "node_modules",
+        "public"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "SkyCrypt",
+  "name": "skycrypt",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1706,6 +1706,12 @@
         "semver": "^5.3.0",
         "tar": "^4"
       }
+    },
+    "node-watch": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
+      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g==",
+      "dev": true
     },
     "nodemon": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "node-watch": "^0.7.1",
     "nodemon": "^2.0.7",
     "sass": "^1.32.5"
   }

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 const cluster = require('cluster');
 const lib = require('./lib');
-const { getFileHashes } = require('./hashes');
+const { getFileHashes, getFileHash, hashedDirectories } = require('./hashes');
 
 async function main(){
     const express = require('express');
@@ -26,6 +26,17 @@ async function main(){
     await renderer.init();
 
     const fileHashes = await getFileHashes();
+
+    if (process.env.NODE_ENV == 'development' || true) {
+        const { default: watch } = await import('node-watch');
+        
+        watch('public/resources', { recursive: true }, async (evt, name) => {
+            const [, , directory, fileName] = name.split(/\/|\\/);
+            if (hashedDirectories.includes(directory)) {
+                fileHashes[directory][fileName] = await getFileHash(name);
+            }
+        });
+    }
 
     const credentials = require(path.resolve(__dirname, '../credentials.json'));
 

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ async function main(){
 
     const fileHashes = await getFileHashes();
 
-    if (process.env.NODE_ENV == 'development' || true) {
+    if (process.env.NODE_ENV == 'development') {
         const { default: watch } = await import('node-watch');
         
         watch('public/resources', { recursive: true }, async (evt, name) => {

--- a/src/hashes.js
+++ b/src/hashes.js
@@ -5,49 +5,55 @@ const util = require('util');
 
 const hashedDirectories = ['js', 'css'];
 
+function getFileHash(filename) {
+    return new Promise((resolve, reject) => {
+        const md5sum = crypto.createHash("md5");
+
+        const s = fs.createReadStream(filename);
+
+        s.on('data', function (data) {
+            md5sum.update(data);
+        });
+
+        s.on('end', function () {
+            const hash = md5sum.digest('hex');
+            resolve(hash);
+        });
+    });
+}
+
+function getFileHashes() {
+    const directoryPromises = hashedDirectories.map(async (directory) => {
+        const readdirPromise = util.promisify(fs.readdir);
+
+        const fileNames = await readdirPromise(path.join(__dirname, "../public/resources", directory));
+
+        const filePromises = fileNames.map(filename => getFileHash(path.join(__dirname, "../public/resources", directory, filename)));
+
+        const fileHashes = await Promise.all(filePromises);
+
+        const hashesObject = {};
+
+        for (let i = 0; i < fileNames.length; i++) {
+            hashesObject[fileNames[i]] = fileHashes[i];
+        }
+
+        return hashesObject;
+    });
+
+    return Promise.all(directoryPromises).then((directories) => {
+        const directoriesObject = {};
+
+        for (let i = 0; i < hashedDirectories.length; i++) {
+            directoriesObject[hashedDirectories[i]] = directories[i];
+        }
+
+        return directoriesObject;
+    });
+}
+
 module.exports = {
-    getFileHashes() {
-        const directoryPromises = hashedDirectories.map(async (directory) => {
-            const readdirPromise = util.promisify(fs.readdir);
-
-            const fileNames = await readdirPromise(path.join(__dirname, "../public/resources", directory));
-
-            const filePromises = fileNames.map(async (filename) => {
-                return new Promise((resolve, reject) => {
-                    const md5sum = crypto.createHash("md5");
-
-                    const s = fs.createReadStream(path.join(__dirname, "../public/resources", directory, filename));
-
-                    s.on('data', function (data) {
-                        md5sum.update(data);
-                    });
-
-                    s.on('end', function () {
-                        const hash = md5sum.digest('hex');
-                        resolve(hash);
-                    });
-                }); 
-            });
-
-            const fileHashes = await Promise.all(filePromises);
-
-            const hashesObject = {};
-
-            for (let i = 0; i < fileNames.length; i++) {
-                hashesObject[fileNames[i]] = fileHashes[i];             
-            }
-
-            return hashesObject;
-        });
-
-        return Promise.all(directoryPromises).then((directories) => {
-            const directoriesObject = {};
-
-            for (let i = 0; i < hashedDirectories.length; i++) {
-                directoriesObject[hashedDirectories[i]] = directories[i];
-            }
-
-            return directoriesObject;
-        });
-    }
+    hashedDirectories,
+    getFileHash,
+    getFileHashes
 }


### PR DESCRIPTION
nodemon does a good job of handling changes to server-side js but the server doesn't need to be reloaded for a change to stats.js this PR fixes that by adding a system to handle changes to js (and css) it also tells nodemon to stay away from pulic