### PR TITLE
use relative units for rarity corner

### DIFF
--- a/public/resources/scss/index.scss
+++ b/public/resources/scss/index.scss
@@ -3965,8 +3965,8 @@ body {
         position: absolute;
         top: 0;
         right: 0;
-        width: 1rem;
-        height: 1rem;
+        width: 20%;
+        height: 20%;
         clip-path: polygon(0 0, 100% 0, 100% 100%);
         border-top-right-radius: 5px;
     }


### PR DESCRIPTION
because the piece is different sizes on mobile and it looks weird to have the corner always be the same size